### PR TITLE
(doc): Docs for makedepf90 with gcc-11.2.0

### DIFF
--- a/docs/source/software/applications/index.rst
+++ b/docs/source/software/applications/index.rst
@@ -87,3 +87,4 @@ and :ref:`Cronos <about_cronos>`) you can review the following entries:
    vsearch/index
    wps/index
    wrf/index
+   makedepf90/index

--- a/docs/source/software/applications/makedepf90/2.8.9/index.rst
+++ b/docs/source/software/applications/makedepf90/2.8.9/index.rst
@@ -1,0 +1,110 @@
+.. _makedepf90-2.8.9:
+
+****************
+Makedepf90 2.8.9
+****************
+
+.. contents:: Table of Contents
+
+Basic Information
+-----------------
+
+- **Deploy Date:** March 28 2022
+- **Downloads page:** https://github.com/outpaddling/makedepf90
+- **Installed on:** APOLO II
+
+Requirements
+------------
+
+- gcc
+- bison
+- flex
+
+Installation
+------------
+
+As the installation process changed for this version the README and readme are deprecated
+
+#. Load the modules you need to compile the desired version of Makedepf90
+
+   .. code-block:: bash
+
+       module load gcc/11.2.0
+
+#. Clone the repository in the directory you are going to compile the application
+
+   .. code-block:: bash
+
+       mkdir build-makedepf90 && cd build-makedepf90
+       git clone https://github.com/outpaddling/makedepf90.git
+       cd makedepf90
+
+#. Open the file Makefile.in and edit the variable DESTDIR to your preference
+
+   .. code-block:: Makefile
+
+       DESTDIR ?= /
+
+#. Run make and then edit the file Makefile again to change the prefix variable.
+
+
+    .. code-block:: bash
+
+        make
+        vim Makefile
+
+    Edit the Makefile that has been written by the command above
+
+    .. code-block:: Makefile
+
+        PREFIX ?= /share/apps/makedepf90/2.8.9/gcc-11.2.0/
+
+#. Run make install as super user to end the installation process
+
+   .. code-block:: bash
+
+       sudo make install
+
+Module
+------
+
+.. code-block:: tcl
+
+    #%Module1.0####################################################################
+    ##
+    ## module load makedepf90/2.8.9_gcc-11.2.0
+    ##
+    ## /share/apps/modules/makedepf90/2.8.9_gcc-11.2.0
+    ## Written by Alejandra Cardenas and Santiago Alzate
+    ##
+
+    proc ModulesHelp {} {
+        global version modroot
+        puts stderr "Sets the environment for using makedepf90 2.8.9\
+                    \nin the shared directory \
+                    \n/share/apps/makedepf90/2.8.9/gcc-11.2.0 builded with\
+                    \ngcc-11.2.0,\
+    }
+
+    module-whatis "(Name________) makedepf90"
+    module-whatis "(Version_____) 2.8.9"
+    module-whatis "(Compilers___) gcc-11.2.0"
+    module-whatis "(System______) x86_64-redhat-linux"
+
+    # for Tcl script use only
+    set         topdir        /share/apps/makedepf90/2.8.9/gcc-11.2.0
+    set         version       2.8.9
+    set         sys           x86_64-redhat-linux
+
+    conflict makedepf90
+
+    module load gcc/11.2.0
+
+    prepend-path    PATH                    $topdir/bin
+
+    prepend-path    MANPATH                 $topdir/share/man
+
+:Authors:
+    Santiago Alzate Cardona <salzatec1@eafit.edu.co>
+
+    Alejandra Cárdenas  <acarden6@eafit.edu.co>

--- a/docs/source/software/applications/makedepf90/index.rst
+++ b/docs/source/software/applications/makedepf90/index.rst
@@ -1,0 +1,25 @@
+.. _makedepf90:
+
+**********
+Makedepf90
+**********
+
+[1]_
+makedepf90 is a program for automatic creation of dependency lists and compilation rules for Makefiles.
+
+makedepf90 supports both modules, include:s, cpp(1) #include:s, f90ppr(1) $include:s and coco(1) ??includes and set-files.
+
+makedepf90 reads Fortran source files given on the command line, and writes a dependency list to stdout; for every file it writes a line with the following format:
+
+   targets : prerequisites
+
+Targets are the files that will be the result of compiling the file with the -c option, and prerequisites are files that are needed to compile the file. In addition, makedepf90 can optionally create the dependency line and make-rule needed to link the final executable.
+
+.. toctree::
+   :caption: Versions
+   :maxdepth: 1
+
+   2.8.9/index
+
+
+.. [1] Edelmann, Erik. makedepf90(1) - Linux man page. Linux Documentation. Retrieved April 4, 2022, from https://linux.die.net/man/1/makedepf90


### PR DESCRIPTION
Created the documentation for makedepf90 version
2.8.9 inside software/applications/makedepf90,
added to the main toctree and a respective index.rst
for each the software and the version.